### PR TITLE
blinky-none-os: don't use GPIOA on CH32V003

### DIFF
--- a/blinky-none-os/src/main.c
+++ b/blinky-none-os/src/main.c
@@ -9,9 +9,14 @@
 #endif
 #include <debug.h>
 
+#ifdef CH32V00X // use PC1 instead of PA1, since PA1 might have a crystal on it
+#define BLINKY_GPIO_PORT GPIOC
+#define BLINKY_CLOCK_ENABLE RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE)
+#else
 #define BLINKY_GPIO_PORT GPIOA
-#define BLINKY_GPIO_PIN GPIO_Pin_1
 #define BLINKY_CLOCK_ENABLE RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE)
+#endif
+#define BLINKY_GPIO_PIN GPIO_Pin_1
 
 void NMI_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void HardFault_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));


### PR DESCRIPTION
This is to follow up on issue #2.